### PR TITLE
H3DS-82 Fixed issue with connecting D455 through USB2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(handy3dscanner LANGUAGES CXX VERSION 0.5.2)
+project(handy3dscanner LANGUAGES CXX VERSION 0.5.3)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 

--- a/src/provider/realsense/rscamera.cpp
+++ b/src/provider/realsense/rscamera.cpp
@@ -6,6 +6,7 @@
 
 #include "src/camera/pointcloud.h"
 #include "src/settings.h"
+#include "src/application.h"
 
 Q_LOGGING_CATEGORY(rscamera, "RSCamera")
 
@@ -79,7 +80,13 @@ void RSCamera::start()
             qCWarning(rscamera) << "Unable to start pipe with the current configuration:" << e.what();
             qCWarning(rscamera) << "Disabling the color stream and retry";
             m_config.disable_stream(RS2_STREAM_COLOR);
-            m_profile = m_pipe->start(m_config);
+            try {
+                m_profile = m_pipe->start(m_config);
+            } catch( rs2::error e ) {
+                Application::I()->error("Unable to start pipeline for this camera. Please report to developer");
+                setIsStreaming(false);
+                return;
+            }
         }
         qCDebug(rscamera) << "get serial";
         m_scanningDeviceSerial = m_profile.get_device().get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);

--- a/src/provider/realsense/rscamera.cpp
+++ b/src/provider/realsense/rscamera.cpp
@@ -169,9 +169,13 @@ void RSCamera::onCameraConnected(const QString &serialNumber)
 
     // Checking usb speed
     if( usb_version.toFloat() < 3.0f ) {
-        m_config.enable_stream(RS2_STREAM_DEPTH, 1280, 720, RS2_FORMAT_Z16, 6);
+        int fr = 6;
+        // D455 is not support the 6fps output, so this improper fix for now
+        if( m_cameraManager.getCameraInfo(serialNumber, RS2_CAMERA_INFO_NAME).contains("D455") )
+            fr = 5;
+        m_config.enable_stream(RS2_STREAM_DEPTH, 1280, 720, RS2_FORMAT_Z16, fr);
         if( Settings::I()->value("Camera.Streams.enable_color_stream").toBool() )
-            m_config.enable_stream(RS2_STREAM_COLOR, 1280, 720, RS2_FORMAT_RGB8, 6);
+            m_config.enable_stream(RS2_STREAM_COLOR, 1280, 720, RS2_FORMAT_RGB8, fr);
     } else {
         m_config.enable_stream(RS2_STREAM_DEPTH, 1280, 720, RS2_FORMAT_Z16, 30);
         if( Settings::I()->value("Camera.Streams.enable_color_stream").toBool() )


### PR DESCRIPTION
* Added D455 exception to use 5fps instead of 6fps on USB2.0 (better solution preparing in #72)
* Show error in case of fail to start the camera pipeline instead of hard fail of the entire application